### PR TITLE
Fix IOException issue on Mac

### DIFF
--- a/distiller.nf
+++ b/distiller.nf
@@ -391,7 +391,7 @@ process merge_stats_runs_into_libraries {
 
 process filter_make_pairs {
     tag "library:${library}"
-    publishDir path:'/', mode:"copy", saveAs: {
+    publishDir path:'.', mode:"copy", saveAs: {
       if( it.endsWith('.nodups.pairs.gz' ))
         return getOutDir("pairs_library") +"/${library}.nodups.pairs.gz"
 


### PR DESCRIPTION
Using root path cause throws an IOException, moreover when `saveAs` returns an absolute path, the path specified by using `path` is ignored.