### PR TITLE
quotes around readlinks fix spaces issue

### DIFF
--- a/distiller.nf
+++ b/distiller.nf
@@ -131,7 +131,7 @@ process fastqc{
 
     """
     mkdir -p ./temp_fastqc/
-    ln -s \$(readlink -f ${fastq}) ./temp_fastqc/${library}.${run}.${side}.fastq.gz
+    ln -s \"\$(readlink -f ${fastq})\" ./temp_fastqc/${library}.${run}.${side}.fastq.gz
     fastqc --threads ${task.cpus} -o ./ -f fastq ./temp_fastqc/${library}.${run}.${side}.fastq.gz
     rm -r ./temp_fastqc/
     """
@@ -345,7 +345,7 @@ process merge_runs_into_libraries {
     script:
     if( isSingleFile(run_pairsam))
         """
-        ln -s \$(readlink -f ${run_pairsam}) ${library}.pairsam.gz
+        ln -s \"\$(readlink -f ${run_pairsam})\" ${library}.pairsam.gz
         """
     else
         """


### PR DESCRIPTION
`readlink` expands a link to a full path without taking care of possible spaces in such path. Wrapping it in quotes solves this issue. 