### PR TITLE
create config profiles, reconcile with distiller

### DIFF
--- a/configs/cluster.config
+++ b/configs/cluster.config
@@ -1,0 +1,97 @@
+process{
+
+    // default LSF node config
+    executor='lsf'
+    queue='short'
+    memory='8 GB'
+    time='4h'
+
+    // use this scope of config
+    // to specify LSF submission node
+    // configuration. Use 'params'
+    // to fine tune cpu requirements
+    // for different scipts inside a process
+
+    //
+    // $download_sra
+    // { use defautls }
+    //
+
+    $fastqc {
+        cpus = 4
+        memory = '4 GB'
+        queue = 'short'
+        time = '2h'
+    }
+
+    $chunk_fastqs {        
+        cpus = 4
+        memory = '2 GB'
+        queue = 'short'
+        time = '2h'
+    }
+
+    $map_runs {
+        cpus = 4
+        memory = '16 GB'
+        queue = 'short'
+        time = '2h'
+    }
+
+    $parse_runs {
+        cpus = 4
+        memory = '8 GB'
+        queue = 'short'
+        time = '1h'
+    }
+
+    $merge_runs_into_libraries {
+        cpus = 8
+        memory = '12 GB'
+        queue = 'short'
+        time = '4h'
+    }
+
+    //
+    // $merge_stats_runs_into_libraries
+    // { use default }
+    //
+
+    $filter_make_pairs {
+        cpus = 8
+        memory = '12 GB'
+        queue = 'short'
+        time = '4h'
+    }
+
+    //
+    // $index_pairs
+    // { use defaults }
+    //
+
+    $bin_library_pairs {
+        cpus = 8
+        memory = '12 GB'
+        queue = 'short'
+        time = '4h'
+    }
+
+    $make_library_group_coolers {
+        cpus = 2
+        memory = '12 GB'
+        queue = 'short'
+        time = '2h'
+    }
+
+    //
+    // $merge_stats_libraries_into_groups
+    // { use defaults }
+    //
+
+
+}
+
+
+docker {
+    enabled = false
+}

--- a/configs/local.config
+++ b/configs/local.config
@@ -1,0 +1,77 @@
+
+process {
+    // default local config
+    executor='local'
+    cpus = 4
+
+    // use this scope of config
+    // to specify local
+    // configuration. Use 'params'
+    // to fine tune cpu requirements
+    // for different scipts inside a process
+
+    // process-specific local config
+    //
+    // $download_sra
+    // { use defautls }
+    //
+
+    $fastqc {
+        cpus = 4
+    }
+
+    $chunk_fastqs {        
+        cpus = 4
+    }
+
+    $map_runs {
+        cpus = 8
+    }
+
+    $parse_runs {
+        cpus = 4
+    }
+
+    $merge_runs_into_libraries {
+        cpus = 8
+    }
+
+    //
+    // $merge_stats_runs_into_libraries
+    // { use default }
+    //
+
+    $filter_make_pairs {
+        cpus = 8
+    }
+
+    //
+    // $index_pairs
+    // { use defaults }
+    //
+
+    $bin_library_pairs {
+        cpus = 8
+    }
+
+    $make_library_group_coolers {
+        cpus = 2
+    }
+
+    //
+    // $merge_stats_libraries_into_groups
+    // { use defaults }
+    //
+
+}
+
+executor {
+    cpus = 40
+}
+
+
+docker {
+    enabled = true
+    runOptions = '-u $(id -u):$(id -g)'
+}
+

--- a/distiller.nf
+++ b/distiller.nf
@@ -156,7 +156,6 @@ process chunk_fastqs {
     tag "library:${library} run:${run}"
     storeDir getIntermediateDir('fastq_chunks')
 
-    cpus params.chunk_cpus
 
     input:
     set val(library), val(run),file(fastq1), file(fastq2) from LIB_RUN_FASTQS_FOR_CHUNK
@@ -234,7 +233,6 @@ process map_runs {
     tag "library:${library} run:${run} chunk:${chunk}"
     storeDir getIntermediateDir('bam_run')
 
-    cpus params.map_cpus
  
     input:
     set val(library), val(run), val(chunk), file(fastq1), file(fastq2) from LIB_RUN_CHUNK_FASTQ
@@ -266,8 +264,6 @@ process parse_runs {
     storeDir getIntermediateDir('pairsam_run')
     publishDir path: getOutDir('stats_run'), pattern: "*.stats", mode:"copy"
 
-    cpus params.parse_cpus
- 
     input:
     set val(library), val(run), file(bam) from LIB_RUN_BAMS
     file(chrom_sizes) from CHROM_SIZES.first()
@@ -334,7 +330,6 @@ process merge_runs_into_libraries {
     tag "library:${library}"
     storeDir getIntermediateDir('pairsam_library')
 
-    cpus params.merge_cpus
  
     input:
     set val(library), file(run_pairsam) from LIB_PAIRSAMS_TO_MERGE
@@ -414,7 +409,6 @@ process filter_make_pairs {
         return getOutDir("stats_library") +"/${library}.dedup.stats.tsv"
     }
 
-    cpus params.filter_make_pairs_cpus
  
     input:
     set val(library), file(pairsam_lib) from LIB_PAIRSAMS
@@ -519,7 +513,6 @@ process bin_library_pairs{
     tag "library:${library} resolution:${res}"
     publishDir path: getOutDir('coolers_library'), mode:"copy", saveAs: {"${library}.${res}.cool"}
 
-    cpus params.bin_cpus
 
     input:
         set val(library), file(pairs_lib), file(pairs_index_lib) from LIB_IDX_PAIRS

--- a/nextflow.config
+++ b/nextflow.config
@@ -8,10 +8,35 @@ manifest {
 process.container = "mirnylab/distiller_env:${version}"
 process.shell = ['/bin/bash', '-uexo','pipefail']
 
-executor {
-    cpus = 40
+
+profiles {
+
+
+    standard {
+        includeConfig './configs/local.config'
+    }
+
+
+    cluster {
+        includeConfig './configs/cluster.config'
+    }
+
 }
 
+// docker context is now described in the
+// scope of profiles
+
+
+// Use 'params' to fine tune
+// cpu requirements for different
+// scipts inside a process, for example:
+// set npzipin to 2 for all processes
+// as pbgzip does not scale further
+// for decompression.
+// Use process scope to define a node config
+// in the LSF submission system.
+// Nice way of separating the two things ...
+// NOT USED IN A CURRENT VERSION AT ALL
 params {
     fastqc_cpus = 4
     chunk_cpus = 8
@@ -22,10 +47,6 @@ params {
     bin_cpus = 20
 }
 
-docker {
-    enabled = true
-    runOptions = '-u $(id -u):$(id -g)'
-}
 
 timeline {
     enabled = true

--- a/project.yml
+++ b/project.yml
@@ -1,10 +1,5 @@
-<<<<<<< HEAD
-do_fastqc: True
-#do_stats: True
-=======
 do_fastqc: False
 do_stats: True
->>>>>>> 2da761b... cluster config draft complete
     
 
 # Fastqs can be provided as:

--- a/project.yml
+++ b/project.yml
@@ -57,9 +57,9 @@ input:
 
 map:
     chunksize: 6000
-    #drop_sam: False
-    #drop_readid: False
-    #drop_seq: False
+    drop_sam: False
+    drop_readid: False
+    drop_seq: False
 
 filter:
     pcr_dups_max_mismatch_bp: 3

--- a/project.yml
+++ b/project.yml
@@ -1,5 +1,10 @@
+<<<<<<< HEAD
 do_fastqc: True
 #do_stats: True
+=======
+do_fastqc: False
+do_stats: True
+>>>>>>> 2da761b... cluster config draft complete
     
 
 # Fastqs can be provided as:


### PR DESCRIPTION
In order to make distiller a true execution polyglot we need to modify its configuration part. Let me start by committing well-tested bits and pieces from our dekkerlab-fork:
--  nextflow.config becomes a high-level description file, which specifies cluster and local profiles (local - is the standard or default one).
--  actual configs for cluster/local execution environment are stored in a ./config folder now
--  specifying cpu-s first on a default level (for all processes) and editing that on a process-specific level (task.cpus is still available from inside of each distiller process)
--  queue and time requirements in cluster.config are specific to umass's ghpcc cluster, but can be used as a template for further modification 