### PR TITLE
separate chunked parse and merge processes

### DIFF
--- a/configs/cluster.config
+++ b/configs/cluster.config
@@ -45,6 +45,13 @@ process{
         time = '1h'
     }
 
+    $merge_chunks_into_runs {
+        cpus = 8
+        memory = '12 GB'
+        queue = 'short'
+        time = '4h'
+    }
+
     $merge_runs_into_libraries {
         cpus = 8
         memory = '12 GB'

--- a/configs/local.config
+++ b/configs/local.config
@@ -32,6 +32,10 @@ process {
         cpus = 4
     }
 
+    $merge_chunks_into_runs {
+        cpus = 8
+    }
+
     $merge_runs_into_libraries {
         cpus = 8
     }

--- a/distiller.nf
+++ b/distiller.nf
@@ -239,7 +239,7 @@ process map_runs {
     set val(bwa_index_base), file(bwa_index_files) from BWA_INDEX.first()
      
     output:
-    set library, run, "${library}.${run}.${chunk}.bam" into LIB_RUN_CHUNK_BAMS
+    set library, run, chunk, "${library}.${run}.${chunk}.bam" into LIB_RUN_CHUNK_BAMS
  
     """
     bwa mem -t ${task.cpus} -SP ${bwa_index_base} ${fastq1} ${fastq2} \
@@ -253,67 +253,39 @@ process map_runs {
  * Parse mapped bams
  */
 
-LIB_RUN_CHUNK_BAMS
-     .groupTuple(by: [0, 1])
-     .set {LIB_RUN_BAMS}
 
 CHROM_SIZES = Channel.from([ file(params.input.genome.chrom_sizes_path) ])
 
 process parse_runs {
-    tag "library:${library} run:${run}"
-    storeDir getIntermediateDir('pairsam_run')
-    publishDir path: getOutDir('stats_run'), pattern: "*.stats", mode:"copy"
+    tag "library:${library} run:${run} chunk:${chunk}"
+    storeDir getIntermediateDir('pairsam_chunk')
 
     input:
-    set val(library), val(run), file(bam) from LIB_RUN_BAMS
+    set val(library), val(run), val(chunk), file(bam) from LIB_RUN_CHUNK_BAMS
     file(chrom_sizes) from CHROM_SIZES.first()
      
     output:
-    set library, run, "${library}.${run}.pairsam.gz" into LIB_RUN_PAIRSAMS
-    set library, run, "${library}.${run}.stats" into LIB_RUN_STATS
+    set library, run, "${library}.${run}.${chunk}.pairsam.gz" into LIB_RUN_CHUNK_PAIRSAMS
  
     script:
     dropsam_flag = params['map'].get('drop_sam','false').toBoolean() ? '--drop-sam' : ''
     dropreadid_flag = params['map'].get('drop_readid','false').toBoolean() ? '--drop-readid' : ''
     dropseq_flag = params['map'].get('drop_seq','false').toBoolean() ? '--drop-seq' : ''
-    stats_command = (params.get('do_stats', 'true').toBoolean() ?
-        "pairsamtools stats ${library}.${run}.pairsam.gz -o ${library}.${run}.stats" :
-        "touch ${library}.${run}.stats" )
-    n_parse_processes = (int)Math.ceil(task.cpus / 2)
-    n_parse_processes = n_parse_processes < 1 ? 1 : n_parse_processes
 
-    if( isSingleFile(bam))
-        """
-        mkdir ./tmp4sort
-        pairsamtools parse ${dropsam_flag} ${dropreadid_flag} ${dropseq_flag} \
-            -c ${chrom_sizes}  ${bam} \
-                | pairsamtools sort --nproc ${task.cpus} \
-                                    -o ${library}.${run}.pairsam.gz \
-                                    --tmpdir ./tmp4sort \
-                | cat
+    """
+    mkdir ./tmp4sort
+    pairsamtools parse ${dropsam_flag} ${dropreadid_flag} ${dropseq_flag} \
+        -c ${chrom_sizes}  ${bam} \
+            | pairsamtools sort --nproc ${task.cpus} \
+                                -o ${library}.${run}.${chunk}.pairsam.gz \
+                                --tmpdir ./tmp4sort \
+            | cat
 
-        rm -rf ./tmp4sort
+    rm -rf ./tmp4sort
 
-        ${stats_command}
-        """
-    else 
-        """
-        mkdir ./tmp4sort
-        mkdir ./tmp_pairsam
-        parallel -P${n_parse_processes} 'pairsamtools parse \
-            ${dropsam_flag} ${dropseq_flag} ${dropreadid_flag} -c ${chrom_sizes} {} \
-            | pairsamtools sort --nproc 4 \
-                                -o ./tmp_pairsam/{}.pairsam.gz \
-                                --tmpdir ./tmp4sort ' ::: ${bam}
-
-        pairsamtools merge ./tmp_pairsam/* --nproc ${task.cpus} -o ${library}.${run}.pairsam.gz
-    
-        rm -rf ./tmp4sort
-        rm -rf ./tmp_pairsam
-
-        ${stats_command}
-        """
+    """
 }
+
 
 
 

--- a/project.yml
+++ b/project.yml
@@ -80,6 +80,7 @@ intermediates:
         downloaded_fastqs: 'downloaded_fastqs/'
         fastq_chunks: 'fastq_chunks'
         bam_run: 'bam/run'
+        pairsam_chunk: 'pairsam/chunk'
         pairsam_run: 'pairsam/run'
         pairsam_library: 'pairsam/library'
 


### PR DESCRIPTION
This commit proposes to separate parsing chunked `BAMs` from merging the resulted `pairsam` chunks. It makes a lot of sense to allow the `nextflow` to treat parsing of each chunk as a separate process and launch these processes on different nodes in a cluster environment. It does create another intermediate folder (`pairsam/chunk`) but we can address that later by merging `mapping` and `parsing` together.

From the code standpoint, we added another process to `distiller`, but the code became a bit cleaner: `if/else` eliminated from parsing step, and we can clean it even further if we decide to use `pairsamtools merge` feature, that leaves file untouched when given just a single input file.

Corresponding `config` files and `project.yml` files were updated accordingly. 