### PR TITLE
comply new pairtools features

### DIFF
--- a/distiller.nf
+++ b/distiller.nf
@@ -9,6 +9,18 @@ vim: syntax=groovy
  * Miscellaneous code for the pipeline
  */
 
+switch(params.compression_format) {
+    case 'gz':
+        suffix = 'gz'
+        break
+    case 'lz4':
+        suffix = 'lz4'
+        break
+    default:
+        suffix = 'gz'
+        break
+}
+
 boolean isSingleFile(object) {    
     object instanceof Path  
 }
@@ -265,7 +277,7 @@ process parse_runs {
     file(chrom_sizes) from CHROM_SIZES.first()
      
     output:
-    set library, run, "${library}.${run}.${chunk}.pairsam.gz" into LIB_RUN_CHUNK_PAIRSAMS
+    set library, run, "${library}.${run}.${chunk}.pairsam.${suffix}" into LIB_RUN_CHUNK_PAIRSAMS
  
     script:
     dropsam_flag = params['map'].get('drop_sam','false').toBoolean() ? '--drop-sam' : ''
@@ -277,7 +289,7 @@ process parse_runs {
     pairsamtools parse ${dropsam_flag} ${dropreadid_flag} ${dropseq_flag} \
         -c ${chrom_sizes}  ${bam} \
             | pairsamtools sort --nproc ${task.cpus} \
-                                -o ${library}.${run}.${chunk}.pairsam.gz \
+                                -o ${library}.${run}.${chunk}.pairsam.${suffix} \
                                 --tmpdir ./tmp4sort \
             | cat
 
@@ -305,22 +317,22 @@ process merge_chunks_into_runs {
     set val(library), val(run), file(pairsam_chunks) from LIB_RUN_GROUP_PAIRSAMS
      
     output:
-    set library, run, "${library}.${run}.pairsam.gz" into LIB_RUN_PAIRSAMS
+    set library, run, "${library}.${run}.pairsam.${suffix}" into LIB_RUN_PAIRSAMS
     set library, run, "${library}.${run}.stats" into LIB_RUN_STATS
  
     script:
     stats_command = (params.get('do_stats', 'true').toBoolean() ?
-        "pairsamtools stats ${library}.${run}.pairsam.gz -o ${library}.${run}.stats" :
+        "pairsamtools stats ${library}.${run}.pairsam.${suffix} -o ${library}.${run}.stats" :
         "touch ${library}.${run}.stats" )
     // can we replace this part with just the "else" branch, so that pairsamtools merge will take care of it?
     if( isSingleFile(pairsam_chunks) )
         """
-        ln -s \"\$(readlink -f ${pairsam_chunks})\" ${library}.${run}.pairsam.gz
+        ln -s \"\$(readlink -f ${pairsam_chunks})\" ${library}.${run}.pairsam.${suffix}
         ${stats_command}
         """
     else
         """
-        pairsamtools merge ${pairsam_chunks} --nproc ${task.cpus} -o ${library}.${run}.pairsam.gz
+        pairsamtools merge ${pairsam_chunks} --nproc ${task.cpus} -o ${library}.${run}.pairsam.${suffix}
         ${stats_command}
         """
 
@@ -344,16 +356,16 @@ process merge_runs_into_libraries {
     set val(library), file(run_pairsam) from LIB_PAIRSAMS_TO_MERGE
      
     output:
-    set library, "${library}.pairsam.gz" into LIB_PAIRSAMS
+    set library, "${library}.pairsam.${suffix}" into LIB_PAIRSAMS
 
     script:
     if( isSingleFile(run_pairsam))
         """
-        ln -s \"\$(readlink -f ${run_pairsam})\" ${library}.pairsam.gz
+        ln -s \"\$(readlink -f ${run_pairsam})\" ${library}.pairsam.${suffix}
         """
     else
         """
-        pairsamtools merge ${run_pairsam} --nproc ${task.cpus} -o ${library}.pairsam.gz
+        pairsamtools merge ${run_pairsam} --nproc ${task.cpus} -o ${library}.pairsam.${suffix}
         """
 }
 

--- a/distiller.nf
+++ b/distiller.nf
@@ -461,7 +461,7 @@ process filter_make_pairs {
                         | pairsamtools split \
                             --output-pairs ${library}.dups.pairs.gz \
                      ) \
-                --stats-file ${library}.dedup.stats \
+                --output-stats ${library}.dedup.stats \
                 | cat
 
         touch ${library}.unmapped.bam
@@ -490,7 +490,7 @@ process filter_make_pairs {
                             --output-pairs ${library}.dups.pairs.gz \
                             --output-sam ${library}.dups.bam \
                      ) \
-                --stats-file ${library}.dedup.stats \
+                --output-stats ${library}.dedup.stats \
                 | cat
 
 

--- a/distiller.nf
+++ b/distiller.nf
@@ -445,24 +445,24 @@ process filter_make_pairs {
     dropsam = params['map'].get('drop_sam','false').toBoolean()
     if(dropsam) 
         """
-        pairsamtools select '(pair_type == "CX") or (pair_type == "LL")' \
+        pairsamtools dedup \
+            --max-mismatch ${params.filter.pcr_dups_max_mismatch_bp} \
+            --mark-dups \
+            --output \
+                >( pairsamtools split \
+                    --output-pairs ${library}.nodups.pairs.gz \
+                 ) \
+            --output-unmapped \
+                >( pairsamtools split \
+                    --output-pairs ${library}.unmapped.pairs.gz \
+                 ) \
+            --output-dups \
+                >( pairsamtools split \
+                    --output-pairs ${library}.dups.pairs.gz \
+                 ) \
+            --output-stats ${library}.dedup.stats \
             ${pairsam_lib} \
-            --output-rest >( pairsamtools split \
-                --output-pairs ${library}.unmapped.pairs.gz \
-                ) | \
-            pairsamtools dedup \
-                --max-mismatch ${params.filter.pcr_dups_max_mismatch_bp} \
-                --output \
-                    >( pairsamtools split \
-                        --output-pairs ${library}.nodups.pairs.gz \
-                     ) \
-                --output-dups \
-                    >( pairsamtools markasdup \
-                        | pairsamtools split \
-                            --output-pairs ${library}.dups.pairs.gz \
-                     ) \
-                --output-stats ${library}.dedup.stats \
-                | cat
+            | cat
 
         touch ${library}.unmapped.bam
         touch ${library}.nodups.bam
@@ -471,28 +471,27 @@ process filter_make_pairs {
         """
     else 
         """
-        pairsamtools select '(pair_type == "CX") or (pair_type == "LL")' \
+        pairsamtools dedup \
+            --max-mismatch ${params.filter.pcr_dups_max_mismatch_bp} \
+            --mark-dups \
+            --output \
+                >( pairsamtools split \
+                    --output-pairs ${library}.nodups.pairs.gz \
+                    --output-sam ${library}.nodups.bam \
+                 ) \
+            --output-unmapped \
+                >( pairsamtools split \
+                    --output-pairs ${library}.unmapped.pairs.gz \
+                    --output-sam ${library}.unmapped.bam \
+                 ) \
+            --output-dups \
+                >( pairsamtools split \
+                    --output-pairs ${library}.dups.pairs.gz \
+                    --output-sam ${library}.dups.bam \
+                 ) \
+            --output-stats ${library}.dedup.stats \
             ${pairsam_lib} \
-            --output-rest >( pairsamtools split \
-                --output-pairs ${library}.unmapped.pairs.gz \
-                --output-sam ${library}.unmapped.bam \
-                ) | \
-            pairsamtools dedup \
-                --max-mismatch ${params.filter.pcr_dups_max_mismatch_bp} \
-                --output \
-                    >( pairsamtools split \
-                        --output-pairs ${library}.nodups.pairs.gz \
-                        --output-sam ${library}.nodups.bam \
-                     ) \
-                --output-dups \
-                    >( pairsamtools markasdup \
-                        | pairsamtools split \
-                            --output-pairs ${library}.dups.pairs.gz \
-                            --output-sam ${library}.dups.bam \
-                     ) \
-                --output-stats ${library}.dedup.stats \
-                | cat
-
+            | cat
 
         """
     

--- a/environment.yml
+++ b/environment.yml
@@ -8,6 +8,7 @@ dependencies:
     - python=3.6
     - parallel
     - pbgzip
+    - lz4-c
     - samtools>=1.4
     - sra-tools>=2.8.1
     - fastqc
@@ -21,5 +22,5 @@ dependencies:
     - pairix
     - pip:
         - cooler>=0.7.1
-        - git+git://github.com/mirnylab/pairsamtools
+        - git+https://github.com/mirnylab/pairsamtools
         - toolz

--- a/nextflow.config
+++ b/nextflow.config
@@ -27,24 +27,23 @@ profiles {
 // scope of profiles
 
 
-// Use 'params' to fine tune
-// cpu requirements for different
-// scipts inside a process, for example:
-// set npzipin to 2 for all processes
-// as pbgzip does not scale further
-// for decompression.
-// Use process scope to define a node config
-// in the LSF submission system.
-// Nice way of separating the two things ...
-// NOT USED IN A CURRENT VERSION AT ALL
+// Use 'params' to provide parameters
+// accessible inside the main script
+// distiller.nf
+
 params {
-    fastqc_cpus = 4
-    chunk_cpus = 8
-    map_cpus = 8
-    merge_cpus = 8
-    parse_cpus = 8
-    filter_make_pairs_cpus = 8
-    bin_cpus = 20
+    // internal compression format (gz, lz4, ...)
+    // used for storing intermediate results
+    compression_format = 'gz'
+
+    //// now retired parameters
+    // fastqc_cpus = 4
+    // chunk_cpus = 8
+    // map_cpus = 8
+    // merge_cpus = 8
+    // parse_cpus = 8
+    // filter_make_pairs_cpus = 8
+    // bin_cpus = 20
 }
 
 


### PR DESCRIPTION
This is a group of throughly tested commits that makes `distiller` compatible with new version of `pairsamtools` and takes advantage of some `pairsamtools'` new features.

- take advantage of new `auto_open` function, able to recognize compression type and apply proper compression program (`lz4`, `gz` so far). Used only for "internal" compression, i.e., intermediate results; all output and input still imply `gz` compression.
- take advantage of new features in `pairsamtools dedup`: skip doing `select`on the pairs, and allow `dedup` itself to filter unmapped reads, same thing with `markasdup`, it is done by `dedup` itself now. This simplified `filter_make_pairs` process of `distiller`, and probably accelerated it (to be tested in big data) .

Note: Travis fails because of the old `pairsamtools` in the current docker (update is pending)

TODO: take advantage of `--nproc-in/out`