### PR TITLE
do stats at parse: new pairsamtools

### DIFF
--- a/configs/cluster.config
+++ b/configs/cluster.config
@@ -60,6 +60,11 @@ process{
     }
 
     //
+    // $merge_stats_chunks_into_runs
+    // { use default }
+    //
+    
+    //
     // $merge_stats_runs_into_libraries
     // { use default }
     //

--- a/configs/local.config
+++ b/configs/local.config
@@ -41,6 +41,11 @@ process {
     }
 
     //
+    // $merge_stats_chunks_into_runs
+    // { use default }
+    //
+
+    //
     // $merge_stats_runs_into_libraries
     // { use default }
     //

--- a/project.yml
+++ b/project.yml
@@ -89,6 +89,7 @@ output:
     dirs:
         fastqc: 'fastqc/'
         pairs_library: 'pairs/library/'
+        stats_chunk: 'stats/chunk/'
         stats_run: 'stats/run/'
         stats_library: 'stats/library/'
         stats_library_group: 'stats/library_group/'


### PR DESCRIPTION
tested commit, that moves statistics gathering to `parsing` step of the pipeline. This way we are getting stats virtually for free (performance degradation is minor - unnoticeable in a cluster environment anyways). Before stats were gathered at the `merge_chunks_in_runs` step by decompressing large `pairsam` file and parsing it one more time - it has proven to be a major slow down, taking almost as much time as the merging itself.

Commit has been tested using test data and big data (1 lane of sequencing data).

We created one more process and an output folder, but we might consider some simplifications afterwards - let's just do single step at a time to avoid braking the whole thing completely.
