### PR TITLE
Balance coolers #45

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -71,10 +71,10 @@ bin:
         - 200000
         - 100000
         - 40000
-        - 20000
-        - 10000
+        # - 20000
+        # - 10000
     balance: True
-    balance_options: ''
+    balance_options: '--tol 0.05'
 
 intermediates:
     base_dir: 'test/intermediates/'

--- a/project.yml
+++ b/project.yml
@@ -73,6 +73,8 @@ bin:
         - 40000
         - 20000
         - 10000
+    balance: True
+    balance_options: ''
 
 intermediates:
     base_dir: 'test/intermediates/'


### PR DESCRIPTION
Trying to address #45 here: simply added a `balance_command` in the binning `process` and in the merge  library group coolers `process`.  Corresponding parameters are stored in the `bin` section of `project.yml`.

I had to edit the binning parameters for the test data to get through, though: 40K, 20K and 10K binning for super-sparse data fails for the default threshold, so I added `--tol 0.05` and commented 20K and 10K altogether.

Commit is tested locally without docker, and doing exactly what you'd expect. Also it's nice that balanced coolers are the same files, so there is no need to create any additional folders.