### PR TITLE
zoomify coolers added as separate process #65

### DIFF
--- a/configs/cluster.config
+++ b/configs/cluster.config
@@ -88,11 +88,25 @@ process{
         time = '4h'
     }
 
+    $zoom_library_coolers {
+        cpus = 8
+        memory = '12 GB'
+        queue = 'short'
+        time = '4h'
+    }
+
     $make_library_group_coolers {
         cpus = 2
         memory = '12 GB'
         queue = 'short'
         time = '2h'
+    }
+
+    $zoom_library_group_coolers {
+        cpus = 8
+        memory = '12 GB'
+        queue = 'short'
+        time = '4h'
     }
 
     //

--- a/configs/local.config
+++ b/configs/local.config
@@ -63,8 +63,16 @@ process {
         cpus = 8
     }
 
+    $zoom_library_coolers {
+        cpus = 8
+    }
+
     $make_library_group_coolers {
         cpus = 2
+    }
+
+    $zoom_library_group_coolers {
+        cpus = 8
     }
 
     //

--- a/distiller.nf
+++ b/distiller.nf
@@ -619,9 +619,9 @@ process zoom_library_coolers{
 
     // additional balancing options as '--balance-args' or empty-line
     balance_options = params['bin'].get('balance_options','')
-    balance_options = ( balance_options ? "--balance-args ${balance_options}": "")
+    balance_options = ( balance_options ? "--balance-args \"${balance_options}\"": "")
     // balancing flag if it's requested
-    balance_flag = ( params['bin'].get('balance','false').toBoolean() ? "--balance \"${balance_options}\"" : "--no-balance" )
+    balance_flag = ( params['bin'].get('balance','false').toBoolean() ? "--balance ${balance_options}" : "--no-balance" )
 
     """
     cooler zoomify \

--- a/distiller.nf
+++ b/distiller.nf
@@ -621,7 +621,7 @@ process zoom_library_coolers{
     balance_options = params['bin'].get('balance_options','')
     balance_options = ( balance_options ? "--balance-args ${balance_options}": "")
     // balancing flag if it's requested
-    balance_flag = ( params['bin'].get('balance','false').toBoolean() ? "--balance ${balance_options}" : "--no-balance" )
+    balance_flag = ( params['bin'].get('balance','false').toBoolean() ? "--balance \"${balance_options}\"" : "--no-balance" )
 
     """
     cooler zoomify \
@@ -709,7 +709,7 @@ process zoom_library_group_coolers{
 
     // additional balancing options as '--balance-args' or empty-line
     balance_options = params['bin'].get('balance_options','')
-    balance_options = ( balance_options ? "--balance-args ${balance_options}": "")
+    balance_options = ( balance_options ? "--balance-args \"${balance_options}\"": "")
     // balancing flag if it's requested
     balance_flag = ( params['bin'].get('balance','false').toBoolean() ? "--balance ${balance_options}" : "--no-balance" )
 

--- a/distiller.nf
+++ b/distiller.nf
@@ -571,7 +571,7 @@ process bin_library_pairs{
         file(chrom_sizes) from CHROM_SIZES.first()
 
     output:
-        set library, res, "${library}.${res}.cool" into LIB_RES_COOLERS
+        set library, res, "${library}.${res}.cool" into LIB_RES_COOLERS, LIB_RES_COOLERS_TO_ZOOM
 
     script:
 
@@ -590,6 +590,48 @@ process bin_library_pairs{
     ${balance_command}
     """
 }
+
+
+/*
+ * Zoomify .cool matrices with highest resolution for libraries (when requested).
+ */ 
+
+// use library-cooler file with the highest resolution (smallest bin size) to zoomify:
+LIB_RES_COOLERS_TO_ZOOM.min{ it[1] as Integer }.set{LIB_RES_COOLERS_TO_ZOOM}
+
+process zoom_library_coolers{
+    tag "library:${library} zoom"
+    publishDir path: getOutDir('zoom_coolers_library'), mode:"copy", saveAs: {"${library}.${res}.multires.cool"}
+
+
+    input:
+        set val(library), val(res), file(cool) from LIB_RES_COOLERS_TO_ZOOM
+
+    output:
+        set library, res, "${library}.${res}.multires.cool" into LIB_RES_COOLERS_ZOOMED
+
+    // run ot only if requested
+    when:
+    params['bin'].get('zoomify','false').toBoolean()
+
+
+    script:
+
+    // additional balancing options as '--balance-args' or empty-line
+    balance_options = params['bin'].get('balance_options','')
+    balance_options = ( balance_options ? "--balance-args ${balance_options}": "")
+    // balancing flag if it's requested
+    balance_flag = ( params['bin'].get('balance','false').toBoolean() ? "--balance ${balance_options}" : "--no-balance" )
+
+    """
+    cooler zoomify \
+        --nproc ${task.cpus} \
+        --out ${library}.${res}.multires.cool \
+        ${balance_flag} \
+        ${cool}
+    """
+}
+
 
 
 /*
@@ -614,7 +656,7 @@ process make_library_group_coolers{
         set val(library_group), val(res), file(coolers) from LIBGROUP_RES_COOLERS_TO_MERGE
 
     output:
-        set library_group, res, "${library_group}.${res}.cool" into LIBGROUP_RES_COOLERS
+        set library_group, res, "${library_group}.${res}.cool" into LIBGROUP_RES_COOLERS, LIBGROUP_RES_COOLERS_TO_ZOOM
 
     script:
 
@@ -637,6 +679,50 @@ process make_library_group_coolers{
         ${balance_command}
         """
 }
+
+
+
+/*
+ * Zoomify .cool matrices with highest resolution for library groups (when requested).
+ */ 
+
+// use library-group-cooler file with the highest resolution (smallest bin size) to zoomify:
+LIBGROUP_RES_COOLERS_TO_ZOOM.min{ it[1] as Integer }.set{LIBGROUP_RES_COOLERS_TO_ZOOM}
+
+process zoom_library_group_coolers{
+    tag "library_group:${library_group} zoom"
+    publishDir path: getOutDir('zoom_coolers_library_group'), mode:"copy", saveAs: {"${library_group}.${res}.multires.cool"}
+
+
+    input:
+        set val(library_group), val(res), file(cool) from LIBGROUP_RES_COOLERS_TO_ZOOM
+
+    output:
+        set library_group, res, "${library_group}.${res}.multires.cool" into LIBGROUP_RES_COOLERS_ZOOMED
+
+    // run ot only if requested
+    when:
+    params['bin'].get('zoomify','false').toBoolean()
+
+
+    script:
+
+    // additional balancing options as '--balance-args' or empty-line
+    balance_options = params['bin'].get('balance_options','')
+    balance_options = ( balance_options ? "--balance-args ${balance_options}": "")
+    // balancing flag if it's requested
+    balance_flag = ( params['bin'].get('balance','false').toBoolean() ? "--balance ${balance_options}" : "--no-balance" )
+
+    """
+    cooler zoomify \
+        --nproc ${task.cpus} \
+        --out ${library_group}.${res}.multires.cool \
+        ${balance_flag} \
+        ${cool}
+    """
+}
+
+
 
 
 /*

--- a/project.yml
+++ b/project.yml
@@ -75,6 +75,7 @@ bin:
         # - 10000
     balance: True
     balance_options: '--tol 0.05'
+    zoomify: True
 
 intermediates:
     base_dir: 'test/intermediates/'
@@ -97,5 +98,7 @@ output:
         stats_library_group: 'stats/library_group/'
         coolers_library: 'coolers/library/'
         coolers_library_group: 'coolers/library_group/'
+        zoom_coolers_library: 'coolers/library_zoom/'
+        zoom_coolers_library_group: 'coolers/library_group_zoom/'
         bams_library: 'bams/library/'
 


### PR DESCRIPTION
Attempt to resolve #65: zoomify added as 2 separate processes `zoom_library_coolers ` and `zoom_library_group_coolers`. Each process start with the highest resolution `.cool` file per library and library_group correspondingly and zoomifies it.

Notes:
- balancing is controlled with the same flag/option used for balancing of single-resolution files
- library_group balancing is performed even if there is only 1 `.cool` per group (should be replaced to copying from corresponding library-level `.cool` ideally)
- extra balancing options are controlled with the same flag/option used for single-res files


Commit is tested locally using the test data. It appears to be doing what one would expect: `.multires.cool`files are indeed multi-res.
