### PR TITLE
extra mapping options added

### DIFF
--- a/distiller.nf
+++ b/distiller.nf
@@ -293,9 +293,13 @@ process map_runs {
      
     output:
     set library, run, chunk, "${library}.${run}.${chunk}.bam" into LIB_RUN_CHUNK_BAMS
+
+    script:
+    // additional mapping options or empty-line
+    mapping_options = params['map'].get('mapping_options','')
  
     """
-    bwa mem -t ${task.cpus} -SP ${bwa_index_base} ${fastq1} ${fastq2} \
+    bwa mem -t ${task.cpus} ${mapping_options} -SP ${bwa_index_base} ${fastq1} ${fastq2} \
         | samtools view -bS > ${library}.${run}.${chunk}.bam \
         | cat
     """

--- a/project.yml
+++ b/project.yml
@@ -60,6 +60,8 @@ map:
     drop_sam: False
     drop_readid: False
     drop_seq: False
+    # just an innocent BWA MEM option to test
+    mapping_options: '-v 3'
 
 filter:
     pcr_dups_max_mismatch_bp: 3


### PR DESCRIPTION
trying to address #70

haven't tested, but the commit is trivial: dummy verbose output option added for `bwa mem`