### PR TITLE
Process error retry

### DIFF
--- a/configs/cluster.config
+++ b/configs/cluster.config
@@ -2,9 +2,17 @@ process{
 
     // default LSF node config
     executor='lsf'
-    queue='short'
     memory='8 GB'
-    time='4h'
+    maxRetries = 2
+    errorStrategy = 'retry'
+    // the coolest feature of 'retry' that
+    // one can dynamically adjust config for
+    // processes - each one individually, or for all
+    // using {task.attempt} as an index of attempt
+    // queue='short'
+    queue = { task.attempt<=1 ? 'short' : 'long' }
+    // time='4h'
+    time = { task.attempt<=1 ? '4h' : '12h' }
 
     // use this scope of config
     // to specify LSF submission node

--- a/configs/local.config
+++ b/configs/local.config
@@ -3,6 +3,14 @@ process {
     // default local config
     executor='local'
     cpus = 4
+    maxRetries = 2
+    errorStrategy = 'retry'
+    // the coolest feature of 'retry' that
+    // one can dynamically adjust config for
+    // processes - each one individually, or for all
+    // using {task.attempt} as an index of attempt
+    cpus = { task.attempt<=1 ? 4 : 8 }
+    // see cluster config for more examples
 
     // use this scope of config
     // to specify local

--- a/distiller.nf
+++ b/distiller.nf
@@ -293,9 +293,13 @@ process map_runs {
      
     output:
     set library, run, chunk, "${library}.${run}.${chunk}.bam" into LIB_RUN_CHUNK_BAMS
+
+    script:
+    // additional mapping options or empty-line
+    mapping_options = params['map'].get('mapping_options','')
  
     """
-    bwa mem -t ${task.cpus} -SP ${bwa_index_base} ${fastq1} ${fastq2} \
+    bwa mem -t ${task.cpus} ${mapping_options} -SP ${bwa_index_base} ${fastq1} ${fastq2} \
         | samtools view -bS > ${library}.${run}.${chunk}.bam \
         | cat
     """

--- a/project.yml
+++ b/project.yml
@@ -60,6 +60,8 @@ map:
     drop_sam: False
     drop_readid: False
     drop_seq: False
+    # just an innocent BWA MEM option to test
+    mapping_options: '-v 3'
 
 filter:
     pcr_dups_max_mismatch_bp: 3


### PR DESCRIPTION
partially addressing #76, no `wget` params adjustment yet, only `nextflow` retry.

It is important regardless of the `wget`, because it introduces dynamical config on retries which is a really cool feature of `nextflow`.

We have been using these features on our cluster since forever, and we can consider them well-tested.
Moreso, using these features made us discover a bug in `nextflow`: https://github.com/nextflow-io/nextflow/issues/412