### PR TITLE
fix zoom: zoom every lib and group

### DIFF
--- a/distiller.nf
+++ b/distiller.nf
@@ -638,7 +638,13 @@ process bin_library_pairs{
  */ 
 
 // use library-cooler file with the highest resolution (smallest bin size) to zoomify:
-LIB_RES_COOLERS_TO_ZOOM.min{ it[1] as Integer }.set{LIB_RES_COOLERS_TO_ZOOM}
+LIB_RES_COOLERS_TO_ZOOM
+    .map{ library,res,cool -> [library,[res,cool]] }
+    .groupTuple( by: 0, sort: {res,cool -> res} )
+    // after grouping by library get res_cool_list with smallest res (highest resoution)
+    .map{ library,res_cool_list -> [library,res_cool_list[0]].flatten() }
+    .set{LIB_RES_COOLERS_TO_ZOOM}
+
 
 process zoom_library_coolers{
     tag "library:${library} zoom"
@@ -728,7 +734,13 @@ process make_library_group_coolers{
  */ 
 
 // use library-group-cooler file with the highest resolution (smallest bin size) to zoomify:
-LIBGROUP_RES_COOLERS_TO_ZOOM.min{ it[1] as Integer }.set{LIBGROUP_RES_COOLERS_TO_ZOOM}
+LIBGROUP_RES_COOLERS_TO_ZOOM
+    .map{ library_group,res,cool -> [library_group,[res,cool]] }
+    .groupTuple( by: 0, sort: {res,cool -> res})
+    // after grouping by library_group get res_cool_list with smallest bin (highest resoution)
+    .map{ library_group,res_cool_list -> [library_group,res_cool_list[0]].flatten() }
+    .set{LIBGROUP_RES_COOLERS_TO_ZOOM}
+
 
 process zoom_library_group_coolers{
     tag "library_group:${library_group} zoom"


### PR DESCRIPTION
@golobor , have noticed cooler `zoomify` process was broken: it would `zoomify` only 1 highest-res cooler per `project`, instead of 1 per each `library` and `library_group`.

This commit fixes that issue, using some `nextflow`-grouping and sorting tools.

Commit has been tested thoroughly, and should do what expected, unless, maybe, some crazy list of resolutions is provided: numerical values are assumed, but no checks implemented.