### PR TITLE
reference singularity in configs to simplify usage

### DIFF
--- a/configs/cluster.config
+++ b/configs/cluster.config
@@ -125,7 +125,26 @@ process{
 
 }
 
+// singularity containers usage example
+// it is disabled by default, but we keep
+// this reference for when it is needed
+singularity {
+    enabled = false
+    // manual mounting of a shared network drive,
+    // very typical for computer clusters.
+    // replace /nearline with the name of shared
+    // space on your cluster, and make sure the
+    // distiller image is modified to include a
+    // mounting point /mount.
+    runOptions = "--bind /nearline:/mount:rw"
+    // shared cluster space can be auto-mounted
+    // when this feature is supported, disabled by default
+    autoMounts = false
+}
 
+
+// docker is rarely an option on
+// big shared clusters.
 docker {
     enabled = false
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -6,9 +6,20 @@ manifest {
 }
 
 process.container = "mirnylab/distiller_env:${version}"
+// specify local singularity image when modifying
+// distiller_env docker image. Example:
+// 1. grab docker and rebuild in a modifiable mode:
+// sudo singularity build --sandbox tmp.img docker://mirnylab/distiller_env:${version}
+// 2. modify it, e.g. add mounting point /my_new_mount:
+// sudo singularity exec --writable tmp.img mkdir /my_new_mount
+// 3. rebuild into read-only image for production:
+// sudo singularity build production_distiller.img tmp.img
+// use process.container = "production_distiller.img" on your cluster.
 process.shell = ['/bin/bash', '-uexo','pipefail']
 
 
+// docker or singularity context is
+// described in the scope of profiles
 profiles {
 
 
@@ -23,14 +34,10 @@ profiles {
 
 }
 
-// docker context is now described in the
-// scope of profiles
-
 
 // Use 'params' to provide parameters
 // accessible inside the main script
 // distiller.nf
-
 params {
     // internal compression format (gz, lz4, ...)
     // used for storing intermediate results


### PR DESCRIPTION
Simply added a most likely scenario for `singularity` containers usage in a disabled by defaults and commented form.

Most of it would probably go to docs at some point

PS [`singularity`](https://www.sylabs.io/) is a container tech used in HPC, where `docker` is not supported for security reasons. `singularity` supports `docker` images though.