### PR TITLE
little config touches for singularity

### DIFF
--- a/configs/cluster.config
+++ b/configs/cluster.config
@@ -20,10 +20,10 @@ process {
     // to fine tune cpu requirements
     // for different scipts inside a process
 
-    //
-    // withName: download_sra
-    // { use defautls }
-    //
+    withName: download_sra{
+        cpu = 2
+        maxForks = 15
+    }
 
     withName: fastqc {
         cpus = 4

--- a/configs/cluster.config
+++ b/configs/cluster.config
@@ -21,7 +21,7 @@ process {
     // for different scipts inside a process
 
     withName: download_sra{
-        cpu = 2
+        cpus = 2
         maxForks = 15
     }
 

--- a/configs/cluster.config
+++ b/configs/cluster.config
@@ -126,19 +126,11 @@ process {
 }
 
 // singularity containers usage example
-// it is disabled by default, but we keep
-// this reference for when it is needed
 singularity {
     enabled = false
-    // manual mounting of a shared network drive,
-    // very typical for computer clusters.
-    // replace /nearline with the name of shared
-    // space on your cluster, and make sure the
-    // distiller image is modified to include a
-    // mounting point /mount.
-    runOptions = "--bind /nearline:/mount:rw"
-    // shared cluster space can be auto-mounted
-    // when this feature is supported, disabled by default
+    // mount external "/nearline" to internal "/mnt"
+    runOptions = "--bind /nearline:/mnt:rw"
+    // enable automount when available
     autoMounts = false
 }
 

--- a/configs/local.config
+++ b/configs/local.config
@@ -21,7 +21,7 @@ process {
     // process-specific local config
 
     withName: download_sra{
-        cpu = 2
+        cpus = 2
         maxForks = 15
     }
 

--- a/configs/local.config
+++ b/configs/local.config
@@ -19,10 +19,11 @@ process {
     // for different scipts inside a process
 
     // process-specific local config
-    //
-    // withName: download_sra
-    // { use defautls }
-    //
+
+    withName: download_sra{
+        cpu = 2
+        maxForks = 15
+    }
 
     withName: fastqc {
         cpus = 4

--- a/nextflow.config
+++ b/nextflow.config
@@ -5,17 +5,11 @@ manifest {
     mainScript = 'distiller.nf'
 }
 
-process.container = "mirnylab/distiller_env:${version}"
-// specify local singularity image when modifying
-// distiller_env docker image. Example:
-// 1. grab docker and rebuild in a modifiable mode:
-// sudo singularity build --sandbox tmp.img docker://mirnylab/distiller_env:${version}
-// 2. modify it, e.g. add mounting point /my_new_mount:
-// sudo singularity exec --writable tmp.img mkdir /my_new_mount
-// 3. rebuild into read-only image for production:
-// sudo singularity build production_distiller.img tmp.img
-// use process.container = "production_distiller.img" on your cluster.
+// docker-hub image is used both with docker and singularity
+// replace with your local image when needed
+process.container = "docker://mirnylab/distiller_env:${version}"
 process.shell = ['/bin/bash', '-uexo','pipefail']
+
 
 // Uncomment this to disable caching in work/ folder.
 // process.cache = false
@@ -51,12 +45,15 @@ params {
 
 timeline {
     enabled = true
+    file = "./pipeline_info/timeline.html"
 }
 
 trace {
     enabled = true
+    file = "./pipeline_info/trace.txt"
 }
 
 report {
     enabled = true
+    file = "./pipeline_info/report.html"
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -7,7 +7,7 @@ manifest {
 
 // docker-hub image is used both with docker and singularity
 // replace with your local image when needed
-process.container = "docker://mirnylab/distiller_env:${version}"
+process.container = "mirnylab/distiller_env:${version}"
 process.shell = ['/bin/bash', '-uexo','pipefail']
 
 


### PR DESCRIPTION
 - cleaned singularity-related comments from configs in favor of https://github.com/mirnylab/distiller-nf/issues/112
 - added `docker://` to the container URI to make it compatible both with docker and singularity
 - added path for `trace`,`report` and `timeline`, so they do not pollute the distiller's "root" folder 