### PR TITLE
Ghpcc

### DIFF
--- a/configs/cluster.config
+++ b/configs/cluster.config
@@ -91,11 +91,7 @@ process {
 
 // singularity containers usage example
 singularity {
-    enabled = false
-    // mount external "/nearline" to internal "/mnt"
-    runOptions = "--bind /nearline:/mnt:rw"
-    // enable automount when available
-    autoMounts = false
+    enabled = true
 }
 
 

--- a/configs/cluster.config
+++ b/configs/cluster.config
@@ -41,8 +41,6 @@ process {
     withName: local_truncate_chunk_fastqs {        
         cpus = 4
         memory = '2 GB'
-        queue = 'short'
-        time = '2h'
     }
 
     withName: fastqc {
@@ -56,29 +54,23 @@ process {
     withName: map_parse_sort_chunks {
         cpus = 8
         memory = '12 GB'
-        queue = 'short'
-        time = '4h'
     }
 
     withName: merge_dedup_splitbam {
         cpus = 4
         memory = '16 GB'
         queue = 'long'
-        time = '12h'
+        time = '15h'
     }
 
     withName: bin_zoom_library_pairs {
         cpus = 8
         memory = '12 GB'
-        queue = 'short'
-        time = '4h'
     }
 
     withName: merge_zoom_library_group_coolers {
         cpus = 8
         memory = '12 GB'
-        queue = 'short'
-        time = '4h'
     }
 
     //

--- a/distiller.nf
+++ b/distiller.nf
@@ -263,7 +263,7 @@ String fastqLocalTruncateChunkCmd(path, library, run, side,
 
 process download_truncate_chunk_fastqs{
     tag "library:${library} run:${run}"
-    storeDir getOutputDir('processed_fastqs')
+    publishDir path: getOutputDir('processed_fastqs')
 
     input:
     set val(library), val(run), 
@@ -306,7 +306,8 @@ process download_truncate_chunk_fastqs{
 
 process local_truncate_chunk_fastqs{
     tag "library:${library} run:${run}"
-    storeDir getOutputDir('processed_fastqs')
+    publishDir path: getOutputDir('processed_fastqs')
+
 
     input:
     set val(library), val(run), 
@@ -394,7 +395,8 @@ LIB_RUN_CHUNK_FASTQS_FOR_QC
 process fastqc{
 
     tag "library:${library} run:${run} chunk:${chunk} side:${side}"
-    storeDir getOutputDir('fastqc')
+    publishDir path: getOutputDir('fastqc'), mode: "copy"
+
 
     input:
     set val(library), val(run), val(chunk), val(side), 
@@ -429,7 +431,7 @@ BWA_INDEX = Channel.from([[
  */
 process map_parse_sort_chunks {
     tag "library:${library} run:${run} chunk:${chunk}"
-    storeDir getOutputDir('mapped_parsed_sorted_chunks')
+    publishDir path: getOutputDir('mapped_parsed_sorted_chunks')
  
     input:
     set val(library), val(run), val(chunk), file(fastq1), file(fastq2) from LIB_RUN_CHUNK_FASTQS
@@ -491,7 +493,7 @@ LIB_RUN_CHUNK_PAIRSAMS
 
 process merge_dedup_splitbam {
     tag "library:${library}"
-    storeDir getOutputDir('pairs_library')
+    publishDir path: getOutputDir('pairs_library'), mode: "copy"
  
     input:
     set val(library), file(run_pairsam) from LIB_PAIRSAMS_TO_MERGE
@@ -579,7 +581,7 @@ FILTERS
 
 process bin_zoom_library_pairs{
     tag "library:${library} filter:${filter_name}"
-    storeDir getOutputDir('coolers_library')
+    publishDir path: getOutputDir('coolers_library'), mode: "copy"
 
     input:
         set val(filter_name), val(filter_expr), val(library), file(pairs_lib) from LIB_FILTER_PAIRS

--- a/nextflow.config
+++ b/nextflow.config
@@ -38,7 +38,7 @@ profiles {
 params {
     // internal compression format (gz, lz4, ...)
     // used for storing intermediate results
-    compression_format = 'gz'
+    compression_format = 'lz4'
 
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -38,12 +38,12 @@ profiles {
 
 
     standard {
-        includeConfig "${config_dir}/local.config"
+        includeConfig "${params.config_dir}/local.config"
     }
 
 
     cluster {
-        includeConfig "${config_dir}/cluster.config"
+        includeConfig "${params.config_dir}/cluster.config"
     }
 
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -27,7 +27,7 @@ params {
     // used for storing intermediate results
     compression_format = 'lz4'
     container_cache_dir = './'
-    config_dir = './configs'
+    custom_config = 'custom.config'
 
 }
 
@@ -38,12 +38,16 @@ profiles {
 
 
     standard {
-        includeConfig "${params.config_dir}/local.config"
+        includeConfig "configs/local.config"
     }
 
 
     cluster {
-        includeConfig "${params.config_dir}/cluster.config"
+        includeConfig "configs/cluster.config"
+    }
+    
+    custom {
+         includeConfig "${params.custom_config}" 
     }
 
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -15,32 +15,39 @@ process.shell = ['/bin/bash', '-uexo','pipefail']
 // process.cache = false
 
 
+// Use 'params' to provide parameters
+// accessible inside the main script
+// distiller.nf
+//
+// parameters from the params section
+// can be modified a command line arguments:
+// nextflow run distiller --compression_format gz --config_dir /shared/path
+params {
+    // internal compression format (gz, lz4, ...)
+    // used for storing intermediate results
+    compression_format = 'lz4'
+    container_cache_dir = './'
+    config_dir = './configs'
+
+}
+
+
 // docker or singularity context is
 // described in the scope of profiles
 profiles {
 
 
     standard {
-        includeConfig './configs/local.config'
+        includeConfig "${config_dir}/local.config"
     }
 
 
     cluster {
-        includeConfig './configs/cluster.config'
+        includeConfig "${config_dir}/cluster.config"
     }
 
 }
 
-
-// Use 'params' to provide parameters
-// accessible inside the main script
-// distiller.nf
-params {
-    // internal compression format (gz, lz4, ...)
-    // used for storing intermediate results
-    compression_format = 'lz4'
-
-}
 
 
 timeline {


### PR DESCRIPTION
I do not mean to PR all of those commits, just to cherry-pick 3 or 4 latest ones.

All for the sake of a "new feature" - sort of:
 - We propose to add a "custom" profile to mainline distiller
 - this would enable users to plugin a custom-config for their specific hardware, like so:
      - `nextflow run mirnylab/distiller-nf -profile custom --custom_config /full/path/to/myhardware.config`
 - the current way of replacing default `local` and `cluster` in the configs folder is a bit inconvenient
     - especially if someone is executing the pipeline like so `nextflow run mirnylab/distiller-nf -profile cluster` - there is no mechanism to substitute whatever is in the `configs` folder in the repo
     - there is a mechanism to substitute default `nextflow.config`, probably - but arguably we don't need that, as we want to keep container path, version and other things - as in defaults, but to customize the hardware-part only
 - maybe eventually we'd get rid of `profile cluster/local`, but for now just merging `custom` seems like easiest

We tried this modification in our fork and tested it using different configs - it works fine .
Also we've switched to this "automated" nextflow pipeline execution : `nextflow run mirnylab/distiller-nf` - which makes `nextflow` to pull latest `distiller-nf` from github (it's stored in `~/.nextflow` by default), run the pipeline and store the results in a different place `./` .

If we agree on this `custom` profile thing, I can try to merge this myself by doing something like this https://mattstauffer.com/blog/how-to-merge-only-specific-commits-from-a-pull-request/