### PR TITLE
update to latest cooler; bump version; docker to be rebuilt

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-version='0.3.1'
+version='0.3.2'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,7 +26,7 @@ RUN conda config --set always_yes yes --set changeps1 no && \
     conda config --add channels conda-forge && \
     conda config --add channels defaults && \
     conda config --add channels bioconda && \
-    conda config --add channels golobor && \ 
+    conda config --add channels golobor && \
     conda config --get && \
     conda update -q conda && \
     conda info -a && \

--- a/environment.yml
+++ b/environment.yml
@@ -23,5 +23,5 @@ dependencies:
     - pairix
     - pairtools
     - pip:
-        - cooler>=0.7.1
+        - git+https://github.com/mirnylab/cooler@develop
         - toolz


### PR DESCRIPTION

trying to resolve https://github.com/mirnylab/distiller-nf/issues/136 in distiller
not sure if installing `git+https://github.com/mirnylab/cooler@develop` is the best - but could be a temporary solution , just to rebuild and republish a container-image , no ?

distiller-tests would fail now, as there is no `mirnylab/distiller_nf:0.3.2` in the dockerhub