### PR TITLE
update readme about custom HW profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `distiller` pipeline aims to provide the following functionality:
 
 Requirements:
 
-- java 7/8
+- java 8
 - [nextflow](https://www.nextflow.io/)
 - docker (should be able to run w/o root privileges, 
 [tutorial](https://www.digitalocean.com/community/tutorials/how-to-install-and-use-docker-on-ubuntu-16-04))
@@ -33,13 +33,24 @@ This will download the distiller pipeline and the configuration files.
 Then:
 - configure the location of the input files and other project details
 in `project.yml`
-- configure the hardware/system details in `nextflow.config` and/or in `./configs/*.config`
+- configure additional parameters in `nextflow.config`
+- use provided hardware configurations using `local` and `cluster` profiles, or provide your own using `custom` profile
 
-Launch distiller as:
+Launch distiller depending on your usage scenario:
 
+1. default hardware settings `./configs/local.config` with your `project.yml`:
 ```sh
-$ nextflow distiller.nf -params-file project.yml
+$ nextflow run distiller.nf -params-file project.yml
 ```
+2. `cluster` hardware profile `./configs/cluster.config` with your `project.yml`:
+```sh
+$ nextflow run distiller.nf -params-file project.yml -profile cluster
+```
+3. `custom` hardware profile with your own configuration file and your `project.yml`:
+```sh
+$ nextflow run distiller.nf -params-file project.yml -profile custom --custom_config /full/path/to/your.config
+```
+
 
 ### Test example
 


### PR DESCRIPTION
our readme is confusing at the moment - and maybe even misleading:
 - just want to take care of the misleading part - clarify the situation with the hardware profiles and add info about custom one
- also java 7 is no more for nextflow, it must be >= 8

[ for future ] - it seems useless to have `cluster/local` configs as they are, we should emphasize that those are examples ; also it's impossible to edit those if you run distiller as `nextflow run mirnylab/distiller-nf ...` i.e. allowing `nextflow` to manage the pipeline .

e.g. maybe we should just have a local/standard - super simple one - and custom with a bunch of examples for the rest 

